### PR TITLE
force scala-xml dependency to 2.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,10 @@ import RemoteDepHelper._
 
 def MyVersion: String = "0.9.18"
 
+// override to match what Scala 2.12.17 uses
+dependencyOverrides in ThisBuild +=
+  "org.scala-lang.modules" %% "scala-xml" % "2.1.0"
+
 def SubProj(name: String) = (
   Project(name, file(if (name=="root") "." else name))
   configs( IntegrationTest )


### PR DESCRIPTION
references #232

locally, `^^1.2.1` followed by `show dependencyClasspath` shows that this is having the intended effect