### PR TITLE
address the scala-xml version conflict a different way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # dbuild release notes
 
-### 0.9.19
+### 0.9.20
 
-- Fix publishing
-
-### 0.9.18
-
-- Force scala-xml dependency to 2.x, for compatibility with sbt 1.8.0
+- Support sbt 1.8.0 (by ignoring scala-xml version conflict)
 - Publish JARs to Maven Central (not Bintray)
 - Publish tarball to GitHub (not Cloudsmith)
+
+### 0.9.19 (withdrawn)
+
+### 0.9.18 (withdrawn)
 
 ### 0.9.17
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,7 @@ You must have rights on Sonatype to publish under `com.typesafe`.
 You should have a `~/.sbt/0.13/sonatype.sbt` (or similar filename)
 with the right `credentials += ...`.
 
-To create a dbuild release,
+To publish a dbuild release,
 
 1. Be sure you are running Java 8
 2. Run `sbt`
@@ -16,8 +16,15 @@ To create a dbuild release,
 Do not try to publish snapshots to Sonatype. Instead, add a custom version
 suffix (such as `-RC1`).
 
-If everything goes well, tag the release and push the tag to GitHub.
-Also update CHANGELOG.md and publish the website (see below).
+If everything goes well, then also:
+
+1. Update CHANGELOG.md
+2. Tag the release
+3. Push the tag to GitHub,
+4. Make a GitHub release from the tag
+5. Run `packageZipTarball`
+6. Attach the resulting `.tgz` and the `.zip` to the GitHub release
+7. Publish the website (see below).
 
 ## Publishing (locally)
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,7 @@
 import Dependencies._
 import RemoteDepHelper._
 
-def MyVersion: String = "0.9.19"
-
-// override to match what Scala 2.12.17 uses
-dependencyOverrides in ThisBuild +=
-  "org.scala-lang.modules" %% "scala-xml" % "2.1.0"
+def MyVersion: String = "0.9.20"
 
 // keep Maven Central happy
 developers in ThisBuild := List(

--- a/build/src/it/scala/com/typesafe/dbuild/build/RewireSpec.scala
+++ b/build/src/it/scala/com/typesafe/dbuild/build/RewireSpec.scala
@@ -28,7 +28,7 @@ object RewireSpec extends Specification {
              |  check-missing: [false, false, false]
              |  cross-version: standard
              |  space: test
-             |  sbt-version: "0.13.8"
+             |  sbt-version: "0.13.18"
              |  extraction-version: "2.11.1"
              |  projects: [
              |    {

--- a/support/src/main/scala/com/typesafe/dbuild/support/sbt/SbtRunner.scala
+++ b/support/src/main/scala/com/typesafe/dbuild/support/sbt/SbtRunner.scala
@@ -334,7 +334,7 @@ object SbtRunner {
    * The string needed to load the dbuild plugin
    */
   val addDBuildPlugin =
-    """libraryDependencySchemes in ThisBuild += "org.scala-lang.modules" %% "scala-xml" % "always"""" + "\n\n" +
+    """dependencyOverrides in ThisBuild += "org.scala-lang.modules" %% "scala-xml" % "2.1.0"""" + "\n\n" +
     """addSbtPlugin("com.typesafe.dbuild" % "plugin" % """ + '"' + Defaults.version + "\")\n\n"
 
   /** Perform a state transformation using onLoad() */

--- a/support/src/main/scala/com/typesafe/dbuild/support/sbt/SbtRunner.scala
+++ b/support/src/main/scala/com/typesafe/dbuild/support/sbt/SbtRunner.scala
@@ -334,6 +334,7 @@ object SbtRunner {
    * The string needed to load the dbuild plugin
    */
   val addDBuildPlugin =
+    """libraryDependencySchemes in ThisBuild += "org.scala-lang.modules" %% "scala-xml" % "always"""" + "\n\n" +
     """addSbtPlugin("com.typesafe.dbuild" % "plugin" % """ + '"' + Defaults.version + "\")\n\n"
 
   /** Perform a state transformation using onLoad() */


### PR DESCRIPTION
the first approach I tried didn't work because the dispatch POM still brings in the old scala-xml dependency version